### PR TITLE
improvements and fixes to libphread

### DIFF
--- a/pthreads/pthread.h
+++ b/pthreads/pthread.h
@@ -1,5 +1,6 @@
 /*
   Copyright (C) 2014 Szilard Biro
+  Copyright (C) 2018 Harry Sintonen
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -89,6 +90,9 @@ struct pthread_attr
 {
 	void *stackaddr;
 	size_t stacksize;
+#ifdef __MORPHOS__
+	size_t stacksize68k;
+#endif
 	int detachstate;
 	struct sched_param param;
 	int inheritsched;

--- a/pthreads/sched.c
+++ b/pthreads/sched.c
@@ -1,5 +1,6 @@
 /*
   Copyright (C) 2014 Szilard Biro
+  Copyright (C) 2018 Harry Sintonen
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -42,6 +43,12 @@ int sched_get_priority_min(int policy)
 
 int sched_yield(void)
 {
+#ifdef __MORPHOS__
+	D(bug("%s()\n", __FUNCTION__));
+	// calling Permit() will trigger a reschedule
+	Forbid();
+	Permit();
+#else
 	BYTE oldpri;
 	struct Task *task;
 
@@ -51,6 +58,7 @@ int sched_yield(void)
 	// changing the priority will trigger a reschedule
 	oldpri = SetTaskPri(task, -10);
 	SetTaskPri(task, oldpri);
+#endif
 
 	return 0;
 }

--- a/pthreads/semaphore.c
+++ b/pthreads/semaphore.c
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 Szilard Biro
+	Copyright (C) 2018 Harry Sintonen
 
 	This software is provided 'as-is', without any express or implied
 	warranty.	In no event will the authors be held liable for any damages
@@ -20,6 +21,7 @@
 
 #include <proto/exec.h>
 
+#include <string.h>
 #include <stdlib.h>
 #include <fcntl.h>
 
@@ -75,8 +77,8 @@ sem_t *sem_open(const char *name, int oflag, mode_t mode, unsigned int value)
 			errno = ENOENT;
 			return SEM_FAILED;
 		}
-		
-		sem = malloc(sizeof(sem_t));
+
+		sem = malloc(sizeof(sem_t) + strlen(name) + 1);
 		if (sem == NULL)
 		{
 			ReleaseSemaphore(&sema_sem);
@@ -90,8 +92,8 @@ sem_t *sem_open(const char *name, int oflag, mode_t mode, unsigned int value)
 			ReleaseSemaphore(&sema_sem);
 			return SEM_FAILED;
 		}
-		// TODO: this string should be duplicated
-		sem->node.ln_Name = (char *)name;
+		sem->node.ln_Name = (STRPTR) (sem + 1);
+		strcpy(sem->node.ln_Name, name);
 		AddTail(&semaphores, (struct Node *)sem);
 	}
 	ReleaseSemaphore(&sema_sem);


### PR DESCRIPTION
The PR fixes a problem where under MorphOS the parent 68k stack size was cloned to the child as PPC stack size.

In addition the timed locking functions are now implemented with Procure()/Vacate() and timer.device UNIT_WAITUTC unit. Also, rather than playing with the task priority, Forbid()/Permit() is used to trigger reschedule. Finally there are some small adjustments to return values and other minor fixes and improvements.